### PR TITLE
Do not throw exception when developing with local repositories

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -84,7 +84,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
             // Allow failures when referencing a branch.
             // Users will likely be developing and be okay with manually compiling files.
             // We assume that tagged releases will exist and not 404.
-            if (preg_match('/^dev-/', $version) || preg_match('/.x-dev$/', $version)) {
+            if (preg_match('/^dev-/', $version) || preg_match('/\.x-dev$/', $version)) {
                 $this->writeDownloadFailedError($subpackage, $url);
             } else {
                 throw $e;

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -84,7 +84,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
             // Allow failures when referencing a branch.
             // Users will likely be developing and be okay with manually compiling files.
             // We assume that tagged releases will exist and not 404.
-            if (strpos($version, 'dev-') === 0) {
+            if (preg_match('/^dev-/', $version) || preg_match('/.x-dev$/', $version)) {
                 $this->writeDownloadFailedError($subpackage, $url);
             } else {
                 throw $e;


### PR DESCRIPTION
When installing Statamic from local composer repository, an exception is thrown from composer-dist-plugin...

![image (5)](https://user-images.githubusercontent.com/5187394/119009052-be8f6680-b960-11eb-8258-9b5b5e886fb3.png)

This PR does what you suggested by writing more graceful error for `.x-dev` suffixes...

![image](https://user-images.githubusercontent.com/5187394/119009140-d535bd80-b960-11eb-958b-ca9bbcf7af66.png)